### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -60,9 +60,9 @@ const fetchImage = async (url, id) => {
         connectionString: process.env.DATABASE_URL,
       })
       await client.connect()
-      const imageUrl = `https://source.unsplash.com/random/300x201?sig=${Math.floor(
+      const imageUrl = `https://picsum.photos/seed/${Math.floor(
         Math.random() * 100
-      )}`
+      )}/300/201`
       const res = await client.query(
         `UPDATE "Bookmark" SET image = $1 WHERE id = $2`,
         [imageUrl, id]


### PR DESCRIPTION
`lib.js` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` (and the related `source.unsplash.com/featured`) was deprecated by Unsplash in mid-2024 and the endpoint now returns HTTP 503 instead of an image. Browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600?office | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Replaces the `imageUrl` template literal in `lib.js` so the bookmark-scraper falls back to a real placeholder image (picsum) instead of writing a 503 URL into the Postgres `Bookmark.image` column.

#### Replacement details

Every scraped bookmark with no og:image was being persisted with a `source.unsplash.com/random/300x201?sig=<N>` URL. Swapping to `picsum.photos/seed/<N>/300/201` keeps the same `sig`-based determinism (same sig → same image) and same dimensions, so existing rows naturally migrate as they're re-scraped.

#### Background

I'm tracking the deprecated `source.unsplash.com/random` endpoint across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. But if you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

One extra artifact you may find handy: a public scanner at <https://tteg.kushalsm.com/scan?url=> that highlights this same broken-URL pattern in any landing page — useful for verifying the fix lands and for finding other places `source.unsplash.com/random` slipped in. Source: <https://github.com/kiluazen/tteg-landing/blob/main/scan.html>.

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
